### PR TITLE
Add AGFRC IB53BHU servo specifications

### DIFF
--- a/IB53BHU-Servo-Specs.md
+++ b/IB53BHU-Servo-Specs.md
@@ -1,0 +1,32 @@
+## AGFRC IB53BHU Servo Specifications
+
+- Model Name: IB53BHU
+- Control Signal: 500 to 2500 uSec
+- Position Signal Voltage: 300 to 3000 mV @180°
+- Control System: Pulse Width Modulation Control
+- Refresh Rate: 333Hz
+- Neutral Position: 1520uS
+- Dead band: 2 uSec
+- Operating Voltage: 4.8V~8.4V
+- Operating Travel: 180°±10°
+- Mechanical Angle: 220°
+- Angle Sensor: Magnet Angle Sensor
+- Temperature: -15C°~ +70C°
+- Motor Type: Brushless
+- Motor Drive: FET Drive
+- Horn Gear Spline: 25T-φ5.92mm
+- Programmable: Yes
+- Bearing: Dual Ball Bearings
+- Bearing Material: Metal
+- Gear Material: Strength Steel
+- Case Material: AL6061T6
+- Certification: CE,FCC,RoHs
+- Wire Guage: JR Dupont 2.54*4PIN 300mm / 22AWG
+- Net Weight: 76.6g (2.7oz)
+- Product Size: 40*20*37.2mm(1.57*0.79*1.46in)
+
+### Additional Information
+
+The AGFRC IB53BHU servo is a high-performance servo ideal for robotics applications requiring precise control and feedback. It features a robust metal gear train, high torque, and a brushless motor for reliable operation. The servo is programmable and comes with a magnet angle sensor for accurate position feedback, making it suitable for advanced robotics projects.
+
+Please note that the wiring diagram will be provided at a later stage once the controller board details are available.


### PR DESCRIPTION
# Add AGFRC IB53BHU Servo Specifications

This pull request adds the documentation for the AGFRC IB53BHU servo specifications to the Project Goose documentation repository. The documentation includes detailed specifications of the servo, which is a high-performance component ideal for robotics applications requiring precise control and feedback.

## Changes
- Created a new markdown file `IB53BHU-Servo-Specs.md` with the servo specifications.

## Link to Devin Run
https://preview.devin.ai/devin/5e381aeb16234cf09e091b64a21e1760

## Requested by
Jack

Please review the changes and provide feedback. Thank you!
