### PR TITLE
Add Waveshare 1.28" LCD ESP32-S3 Board Documentation

### DIFF
--- a/Waveshare-ESP32-S3-LCD-1.28-Specs.md
+++ b/Waveshare-ESP32-S3-LCD-1.28-Specs.md
@@ -1,0 +1,53 @@
+# Waveshare 1.28" LCD ESP32-S3 Board Specifications
+
+The Waveshare 1.28" LCD ESP32-S3 board is a versatile and powerful component used for modular control of the robot joints in Project Goose. This board features a 1.27mm pitch header and is not the touchscreen model. It supports two operating modes: single servo mode and tandem servo mode, where servos are driven in opposite directions for 180-degree operation.
+
+## Specifications
+
+- **Model**: Waveshare 1.28" LCD ESP32-S3
+- **Header Pitch**: 1.27mm
+- **Operating Modes**:
+  - **Single Servo Mode**: Controls a single servo.
+  - **Tandem Servo Mode**: Controls two servos in opposite directions for 180-degree operation.
+
+## Pinout
+
+Below is the pinout diagram for the Waveshare 1.28" LCD ESP32-S3 board:
+
+![Waveshare 1.28" LCD ESP32-S3 Pinout](https://api.devin.ai/attachments/3e784e38-aba2-43ff-b39f-2c3e597eda38/ESP32-S3-LCD-1.28-details-inter.jpg)
+
+## Usage
+
+The Waveshare 1.28" LCD ESP32-S3 board will be used in Project Goose to create a modular control system for the robot joints. Each joint will have one board, allowing for extensibility and future enhancements in robotics projects.
+
+### Single Servo Mode
+
+In single servo mode, the board controls a single servo, providing precise control and feedback for the robot joint.
+
+### Tandem Servo Mode
+
+In tandem servo mode, the board controls two servos that are driven in opposite directions. This mode is useful for achieving 180-degree operation angles, where one servo moves forward while the other moves backward.
+
+## Installation
+
+1. Connect the Waveshare 1.28" LCD ESP32-S3 board to the robot joint using the 1.27mm pitch headers.
+2. Configure the board for the desired operating mode (single servo or tandem servo).
+3. Ensure proper power supply and signal connections as per the pinout diagram.
+
+## Maintenance
+
+- Regularly check the connections and ensure that the headers are securely attached.
+- Keep the board clean and free from dust and debris.
+- Update the firmware as needed to ensure optimal performance.
+
+## Troubleshooting
+
+- If the board is not responding, check the power supply and signal connections.
+- Verify that the board is configured for the correct operating mode.
+- Consult the Waveshare documentation for additional troubleshooting steps.
+
+For more information and detailed specifications, visit the [Waveshare product page](https://www.waveshare.com/esp32-s3-lcd-1.28.htm).
+
+---
+
+This documentation is part of Project Goose, an open-source initiative to create a high-performance robot arm at a fraction of the cost. For more details, visit the [Project Goose GitHub repository](https://github.com/jhacksman/Project-Goose-Docs).


### PR DESCRIPTION
# Add Waveshare 1.28" LCD ESP32-S3 Board Specifications

This pull request adds the documentation for the Waveshare 1.28" LCD ESP32-S3 board specifications to the Project Goose documentation repository. The documentation includes detailed specifications of the board, which is a versatile and powerful component used for modular control of the robot joints.

## Changes
- Created a new markdown file `Waveshare-ESP32-S3-LCD-1.28-Specs.md` with the board specifications, pinout image, usage instructions, installation steps, maintenance tips, and troubleshooting advice.

## Link to Devin Run
https://preview.devin.ai/devin/5e381aeb16234cf09e091b64a21e1760

## Requested by
Jack

Please review the changes and provide feedback. Thank you!
