### PR TITLE
Add Waveshare Shield Requirements

### DIFF
--- a/Waveshare-Shield-Requirements.md
+++ b/Waveshare-Shield-Requirements.md
@@ -1,0 +1,66 @@
+# Waveshare Shield Requirements
+
+## Overview
+The Waveshare Shield is a companion board designed to interface with the Waveshare 1.28" LCD ESP32-S3 board. It will provide additional functionalities and connectivity options to support the operation of the robot arm in Project Goose.
+
+## Components
+1. **Waveshare 1.28" LCD ESP32-S3 Board**
+   - 1.27mm pitch headers
+   - 2x 20-pin headers for connection to the shield
+
+2. **ACS712 Current Sensors**
+   - Quantity: 2
+   - Current rating: 5A each
+   - Purpose: Measure current draw of servos
+
+3. **Buck Converter**
+   - Input voltage: 7.5V
+   - Output voltage: 5V
+   - Purpose: Step down voltage to power the Waveshare board and shield
+
+4. **I2C Headers**
+   - Purpose: Provide I2C connectivity for additional sensors and modules
+
+5. **Common Ground**
+   - Purpose: Ensure all components share a common electrical ground
+
+## Electrical Characteristics
+- **Input Voltage:** 7.5V from main PSU
+- **Output Voltage:** 5V from buck converter
+- **Current Handling:** Up to 5A per ACS712 sensor
+- **Power Supply for Servos:** 7.5V, 5600mA per servo (tandem mode: 11.2A total)
+
+## Physical Constraints
+- **Board Size:** To be determined based on component layout
+- **Header Placement:** Ensure proper alignment with Waveshare board headers
+- **Mounting Holes:** Include mounting holes for secure attachment
+
+## Functionalities
+1. **Current Sensing:**
+   - Measure current draw of servos using ACS712 sensors
+   - Provide data for monitoring and safety
+
+2. **Voltage Regulation:**
+   - Step down 7.5V to 5V using buck converter
+   - Power the Waveshare board and shield
+
+3. **I2C Connectivity:**
+   - Provide headers for connecting additional I2C sensors and modules
+
+4. **Modularity:**
+   - Support single servo mode and tandem servo mode
+   - Allow for future expansion and customization
+
+## Design Considerations
+- **Thermal Management:** Ensure adequate cooling for components
+- **Signal Integrity:** Minimize noise and interference in signal lines
+- **Safety:** Include protection mechanisms for overcurrent and overvoltage conditions
+
+## Next Steps
+1. Create a schematic diagram based on the requirements outlined above.
+2. Review the schematic for accuracy and completeness.
+3. Proceed with PCB layout and prototyping.
+
+---
+
+Please review the requirements and provide feedback or additional specifications as needed.

--- a/Waveshare-Shield-Schematic-Connections.md
+++ b/Waveshare-Shield-Schematic-Connections.md
@@ -1,0 +1,31 @@
+# Waveshare Shield Schematic Connections
+
+This document outlines the detailed connections for the Waveshare Shield schematic, which includes the power supply, ACS712 current sensor connections, servo connections, position feedback connections, and common ground. This guide is intended to be used in KiCad or any other PCB design software to create the schematic.
+
+## Power Supply Connections
+- Connect the 7.5V power input to the input of the buck converter.
+- Connect the 5V output from the buck converter to the VCC of the Waveshare board and both ACS712 modules.
+
+## ACS712 Current Sensor Connections
+- Connect the 7.5V line to the VCC of each ACS712 module.
+- Connect the ground of each ACS712 module to the common ground.
+- Connect the output of each ACS712 module to separate analog input pins on the ESP32-S3 for current sensing.
+
+## Servo Connections
+- Connect the 7.5V line to the VCC of each servo, ensuring there are two separate lines for the tandem setup.
+- Connect the ground of each servo to the common ground.
+- Connect a digital pin for the PWM signal to control the servo.
+
+## Position Feedback Connections
+- Provide a separate 1-pin connector for the position feedback from the servo, which will be connected to an analog input on the ESP32-S3.
+
+## Common Ground
+- Ensure that there is a common ground connection for all components.
+
+## Labeling
+- Label all connections, components, and voltages clearly.
+
+## Review
+- Review the schematic for any errors or missing connections.
+
+This document should be used as a guide to create the schematic in KiCad or any other PCB design software. Once the schematic is drafted, it should be reviewed for accuracy and completeness before proceeding with the PCB layout and prototyping.


### PR DESCRIPTION
# Add Waveshare Shield Requirements

This pull request adds the requirements documentation for the Waveshare Shield to the Project Goose documentation repository. The documentation outlines the necessary features and specifications for designing the shield, which is a companion board for the Waveshare 1.28" LCD ESP32-S3 board. The shield includes two ACS712 (5A) current sensors, a buck converter, i2c headers, and a common ground.

## Changes
- Created a new markdown file `Waveshare-Shield-Requirements.md` with the shield requirements, including components, electrical characteristics, physical constraints, functionalities, design considerations, and next steps.

## Link to Devin Run
https://preview.devin.ai/devin/5e381aeb16234cf09e091b64a21e1760

## Requested by
Jack

Please review the changes and provide feedback. Thank you!
