### PR TITLE
Add dimensions and layout details for Waveshare Shield

### DIFF
--- a/Waveshare-Shield-Schematic-Connections.md
+++ b/Waveshare-Shield-Schematic-Connections.md
@@ -28,4 +28,11 @@ This document outlines the detailed connections for the Waveshare Shield schemat
 ## Review
 - Review the schematic for any errors or missing connections.
 
+## Dimensions and Layout
+- The radius of the circular part of the Waveshare 1.28" LCD ESP32-S3 board is 18.25 mm.
+- The distance between the two sets of 2x10 pin headers on the flat edge is 12.81 mm.
+- The width of the flat edge, where the USB-C connector is located, is 18.37 mm.
+- The distance from the center of the board to the flat edge is 27.00 mm.
+- The pin headers are spaced at 1.27 mm intervals.
+
 This document should be used as a guide to create the schematic in KiCad or any other PCB design software. Once the schematic is drafted, it should be reviewed for accuracy and completeness before proceeding with the PCB layout and prototyping.

--- a/Waveshare-Shield-Schematic-Draft.md
+++ b/Waveshare-Shield-Schematic-Draft.md
@@ -1,0 +1,62 @@
+# Waveshare Shield Schematic Draft
+
+## Components and Connections Layout
+
+### Components
+1. **ACS712 Current Sensor Modules (2x)**
+   - Sensor 1: ACS712-1
+   - Sensor 2: ACS712-2
+
+2. **Buck Converter**
+   - Input Voltage: 7.5V
+   - Output Voltage: 5V
+
+3. **Servo Connectors**
+   - 3-pin Connector: Power (7.5V), Ground, PWM Signal
+   - 1-pin Connector: Position Feedback
+
+4. **Waveshare Board Connectors**
+   - 2x 20-pin Connectors
+   - Pin Pitch: 1.27mm
+   - Distance between connectors: 27.00mm (center to center)
+   - Orientation: USB-C port at the top center
+
+5. **I2C Headers**
+   - SDA, SCL
+
+6. **Common Ground**
+
+### Connections
+1. **Power Distribution**
+   - 7.5V from power source to Buck Converter input
+   - 5V from Buck Converter output to Waveshare board and ACS712 modules
+
+2. **ACS712 Current Sensors**
+   - 7.5V input to ACS712-1 sensor port
+   - 7.5V input to ACS712-2 sensor port
+   - Sensor output (0V to 2.5V) to Waveshare board analog input (ensure correct orientation)
+
+3. **Servo Connectors**
+   - 3-pin Connector:
+     - Pin 1: Ground (black)
+     - Pin 2: 7.5V Power (red)
+     - Pin 3: PWM Signal (white, digital pin from Waveshare board)
+   - 1-pin Connector:
+     - Pin 1: Position Feedback (analog pin from Waveshare board)
+
+4. **I2C Headers**
+   - SDA to Waveshare board SDA pin
+   - SCL to Waveshare board SCL pin
+
+5. **Common Ground**
+   - Connect all ground pins to a common ground plane
+
+### Notes
+- Ensure that the ACS712 sensors are correctly oriented to measure current flow in the desired direction.
+- Verify the pinout and orientation of the 20-pin connectors on the Waveshare board once the details are confirmed.
+- Double-check the connections for the servo connectors to ensure proper functionality.
+
+## Next Steps
+- Review the schematic draft with the user for accuracy and completeness.
+- Proceed with the actual schematic drawing in KiCad based on the confirmed details.
+- Finalize the PCB layout and prepare for prototyping.


### PR DESCRIPTION
# Add Waveshare Shield Requirements

This pull request adds the requirements documentation for the Waveshare Shield to the Project Goose documentation repository. The documentation outlines the necessary features and specifications for designing the shield, which is a companion board for the Waveshare 1.28" LCD ESP32-S3 board. The shield includes two ACS712 (5A) current sensors, a buck converter, i2c headers, and a common ground.

## Changes
- Created a new markdown file `Waveshare-Shield-Requirements.md` with the shield requirements, including components, electrical characteristics, physical constraints, functionalities, design considerations, and next steps.
- Added dimensions and layout details for the Waveshare Shield in the `Waveshare-Shield-Schematic-Connections.md` file.

## Link to Devin Run
https://preview.devin.ai/devin/5e381aeb16234cf09e091b64a21e1760

## Requested by
Jack

Please review the changes and provide feedback. Thank you!
