### PR TITLE
Add TWAI Protocol Headers to Comprehensive Documentation

### DIFF
--- a/Waveshare-Shield-Comprehensive-Documentation.md
+++ b/Waveshare-Shield-Comprehensive-Documentation.md
@@ -31,6 +31,17 @@ The Waveshare Shield is a companion board designed to work with the Waveshare 1.
 - **Pin Pitch:** 1.27mm
 - **Voltage:** 3.3V/5V
 
+### TWAI Protocol Headers
+- **Protocol:** TWAI (Two-Wire Automotive Interface)
+- **Compatibility:** ISO11898-1 Classical frames
+- **Controller:** ESP32 TWAI controller
+- **External Transceiver:** Required to connect TWAI controller to TWAI bus
+- **Pin Configuration:**
+  - **Pin 1:** TWAI_TX (Transmit)
+  - **Pin 2:** TWAI_RX (Receive)
+  - **Pin 3:** Ground
+  - **Pin 4:** 5V Power
+
 ### 4. Common Ground
 - **Description:** A common ground connection for all components on the shield to ensure proper electrical grounding and signal integrity.
 


### PR DESCRIPTION
# Add TWAI Protocol Headers to Comprehensive Documentation

This pull request adds TWAI protocol headers to the comprehensive documentation for the Waveshare Shield, detailing the TWAI protocol, required headers, and external transceiver.

## Changes
- Added a new section titled "TWAI Protocol Headers" to the comprehensive documentation, detailing the TWAI protocol, required headers, and external transceiver.

## Link to Devin Run
https://preview.devin.ai/devin/5e381aeb16234cf09e091b64a21e1760

## Requested by
Jack

Please review the changes and provide feedback. Thank you!
